### PR TITLE
The order of the arguments in the dispatcher uses is adjusted

### DIFF
--- a/src/Command/QueueReceiveCommand.php
+++ b/src/Command/QueueReceiveCommand.php
@@ -103,7 +103,7 @@ class QueueReceiveCommand extends Command implements ContainerAwareInterface
         if($messages) {
             foreach ($messages as $message) {
                 $messageEvent = new MessageEvent($name, $message);
-                $dispatcher->dispatch(Events::Message($name), $messageEvent);
+                $dispatcher->dispatch($messageEvent, Events::Message($name));
             }
         }
 

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -102,8 +102,8 @@ class RequestListener {
 		);
 
 		$this->dispatcher->dispatch(
-			Events::Notification($queue),
-			new NotificationEvent($queue, NotificationEvent::TYPE_MESSAGE, $notification)
+			new NotificationEvent($queue, NotificationEvent::TYPE_MESSAGE, $notification),
+			Events::Notification($queue)
 		);
 
 		return "IronMQ Notification Received.";
@@ -139,8 +139,8 @@ class RequestListener {
 			);
 
 			$this->dispatcher->dispatch(
-				Events::Notification($queue),
-				new NotificationEvent($queue, NotificationEvent::TYPE_MESSAGE, $notification)
+				new NotificationEvent($queue, NotificationEvent::TYPE_MESSAGE, $notification),
+				Events::Notification($queue)
 			);
 
 			return "SNS Message Notification Received.";
@@ -162,8 +162,8 @@ class RequestListener {
 		);
 
 		$this->dispatcher->dispatch(
-			Events::Notification($queue),
-			new NotificationEvent($queue, NotificationEvent::TYPE_SUBSCRIPTION, $notification)
+			new NotificationEvent($queue, NotificationEvent::TYPE_SUBSCRIPTION, $notification),
+			Events::Notification($queue)
 		);
 
 		return "SNS Subscription Confirmation Received.";

--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -646,9 +646,8 @@ class AwsProvider extends AbstractProvider
 
         $messages = $this->receive();
         foreach ($messages as $message) {
-
             $messageEvent = new MessageEvent($this->name, $message);
-            $dispatcher->dispatch(Events::Message($this->name), $messageEvent);
+            $dispatcher->dispatch($messageEvent, Events::Message($this->name));
         }
     }
 

--- a/src/Provider/IronMqProvider.php
+++ b/src/Provider/IronMqProvider.php
@@ -298,8 +298,8 @@ class IronMqProvider extends AbstractProvider
         $messageEvent = new MessageEvent($this->name, $message);
 
         $dispatcher->dispatch(
-            Events::Message($this->name),
-            $messageEvent
+            $messageEvent,
+            Events::Message($this->name)
         );
     }
 


### PR DESCRIPTION
The order of the arguments in the dispatcher uses is adjusted for use in SF5